### PR TITLE
Fix module content parser

### DIFF
--- a/galaxyjs/galaxy.js
+++ b/galaxyjs/galaxy.js
@@ -2102,7 +2102,8 @@ Galaxy.Module.Content = /** @class */ (function () {
    * @returns {*}
    */
   Content.parse = function (ModuleContent) {
-    const parser = parsers[ModuleContent.type];
+    const safeType = (ModuleContent.type || '').split(';')[0];
+    const parser = parsers[safeType];
 
     if (parser) {
       return parser.call(null, ModuleContent.content, ModuleContent.metaData);


### PR DESCRIPTION
Fix content-type was not parsing properly to a correct type when loading modules.